### PR TITLE
Handle newline \n\n in the string

### DIFF
--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -8,15 +8,16 @@ tokenizer = re.compile(r"((?:[^()\s]+|[().?!-])\s*)")
 newline_pattern = re.compile(r"((?:\n[ ]*){2,})")
 
 
-
 def tokenize_text(text: str) -> list[str]:
     return re.findall(tokenizer, text)
+
 
 def split_newlines(text: str) -> tuple(list[str], list[str]):
     """
     Splits a string into a list of strings, and a list of substring containing newlines.
     :param text: The text to split.
-    :return: A tuple containing the list of strings, and a list of substring containing newlines."""
+    :return: A tuple containing the list of strings, and a list of substring containing newlines.
+    """
     return re.split(newline_pattern, text), re.findall(newline_pattern, text)
 
 
@@ -70,9 +71,12 @@ class Redlines:
         Similar to `SequenceMatcher.get_opcodes`
         """
         if self._seq2 is None:
-            raise ValueError('No test string was provided when the function was called, or during initialisation.')
+            raise ValueError(
+                "No test string was provided when the function was called, or during initialisation."
+            )
 
         from difflib import SequenceMatcher
+
         matcher = SequenceMatcher(None, self._seq1, self._seq2)
         return matcher.get_opcodes()
 
@@ -80,16 +84,21 @@ class Redlines:
     def output_markdown(self) -> str:
         """Returns the delta in markdown format."""
         result = []
-        style = 'red'
+        style = "red"
 
-        if self.options.get('markdown_style'):
-            style = self.options['markdown_style']
+        if self.options.get("markdown_style"):
+            style = self.options["markdown_style"]
 
-        if style == 'none':
-            md_styles = {"ins": ('ins', 'ins'), "del": ('del', 'del')}
-        elif 'red':
-            md_styles = {"ins": ('span style="color:red;font-weight:700;"', 'span'),
-                         "del": ('span style="color:red;font-weight:700;text-decoration:line-through;"', 'span')}
+        if style == "none":
+            md_styles = {"ins": ("ins", "ins"), "del": ("del", "del")}
+        elif "red":
+            md_styles = {
+                "ins": ('span style="color:red;font-weight:700;"', "span"),
+                "del": (
+                    'span style="color:red;font-weight:700;text-decoration:line-through;"',
+                    "span",
+                ),
+            }
 
         for tag, i1, i2, j1, j2 in self.opcodes:
             if tag == "equal":
@@ -105,14 +114,14 @@ class Redlines:
                             f"<{md_styles['ins'][0]}>{s}</{md_styles['ins'][1]}>"
                         )
             elif tag == "delete":
-                temp_str = "".join(self._seq1[i1:i2]).replace('\n', '')
+                temp_str = "".join(self._seq1[i1:i2]).replace("\n", "")
                 result.append(
                     f"<{md_styles['del'][0]}>{temp_str}</{md_styles['del'][1]}>"
                 )
             elif tag == "replace":
-                temp_str1 = "".join(self._seq1[i1:i2]).replace('\n', '')
+                temp_str = "".join(self._seq1[i1:i2]).replace("\n", "")
                 result.append(
-                    f"<{md_styles['del'][0]}>{temp_str1}</{md_styles['del'][1]}>"
+                    f"<{md_styles['del'][0]}>{temp_str}</{md_styles['del'][1]}>"
                 )
 
                 temp_str = "".join(self._seq2[j1:j2])
@@ -128,7 +137,6 @@ class Redlines:
         return "".join(result)
 
     def compare(self, test: str | None = None, output: str = "markdown", **options):
-
         """
         Compare `test` with `source`, and produce a delta in a format specified by `output`.
 
@@ -142,10 +150,12 @@ class Redlines:
             else:
                 self.test = test
         elif self.test is None:
-            raise ValueError('No test string was provided when the function was called, or during initialisation.')
+            raise ValueError(
+                "No test string was provided when the function was called, or during initialisation."
+            )
 
         if options:
             self.options = options
 
-        if output == 'markdown':
+        if output == "markdown":
             return self.output_markdown

--- a/tests/test_redline.py
+++ b/tests/test_redline.py
@@ -76,3 +76,28 @@ def test_markdown_style():
                   'over </span><span style="color:red;font-weight:700;">walks past </span>the lazy dog.'
     test = Redlines(test_string_1, markdown_style='red')
     assert test.compare(test_string_2) == expected_md
+
+
+def test_newline_handling():
+    test_string_1 = '''
+Happy Saturday,
+
+Thank you for reaching out, have a good weekend
+
+Sophia 
+'''
+    test_string_2 = '''Happy Saturday,
+
+Thank you for reaching out. Have a good weekend.
+
+Sophia.'''
+    expected_md = 'Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekendSophia </del><ins>weekend.</ins>\n\n<ins>Sophia.</ins>'
+    test = Redlines(test_string_1, markdown_style='none')
+    assert test.compare(test_string_2) == expected_md
+
+
+    expected_md = 'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekendSophia </span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;">Sophia.</span>'
+    test = Redlines(test_string_1, markdown_style='red')
+    assert test.compare(test_string_2) == expected_md
+
+

--- a/tests/test_redline.py
+++ b/tests/test_redline.py
@@ -3,48 +3,67 @@ import pytest
 from redlines import Redlines
 
 
-@pytest.mark.parametrize("test_string_1, test_string_2, expected_md", [
-    ("The quick brown fox jumps over the dog.",
-     "The quick brown fox jumps over the lazy dog.",
-     "The quick brown fox jumps over the <ins>lazy </ins>dog.")
-])
+@pytest.mark.parametrize(
+    "test_string_1, test_string_2, expected_md",
+    [
+        (
+            "The quick brown fox jumps over the dog.",
+            "The quick brown fox jumps over the lazy dog.",
+            "The quick brown fox jumps over the <ins>lazy </ins>dog.",
+        )
+    ],
+)
 def test_redline_add(test_string_1, test_string_2, expected_md):
-    test = Redlines(test_string_1, test_string_2, markdown_style='none')
+    test = Redlines(test_string_1, test_string_2, markdown_style="none")
     assert test.output_markdown == expected_md
 
 
-@pytest.mark.parametrize("test_string_1, test_string_2, expected_md", [
-    ("The quick brown fox jumps over the lazy dog.",
-     "The quick brown fox jumps over the dog.",
-     "The quick brown fox jumps over the <del>lazy </del>dog.")
-])
+@pytest.mark.parametrize(
+    "test_string_1, test_string_2, expected_md",
+    [
+        (
+            "The quick brown fox jumps over the lazy dog.",
+            "The quick brown fox jumps over the dog.",
+            "The quick brown fox jumps over the <del>lazy </del>dog.",
+        )
+    ],
+)
 def test_redline_delete(test_string_1, test_string_2, expected_md):
-    test = Redlines(test_string_1, test_string_2, markdown_style='none')
+    test = Redlines(test_string_1, test_string_2, markdown_style="none")
     assert test.output_markdown == expected_md
 
 
-@pytest.mark.parametrize("test_string_1, test_string_2, expected_md", [
-    ("The quick brown fox jumps over the lazy dog.",
-     "The quick brown fox walks past the lazy dog.",
-     "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog.")
-])
+@pytest.mark.parametrize(
+    "test_string_1, test_string_2, expected_md",
+    [
+        (
+            "The quick brown fox jumps over the lazy dog.",
+            "The quick brown fox walks past the lazy dog.",
+            "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog.",
+        )
+    ],
+)
 def test_redline_replace(test_string_1, test_string_2, expected_md):
-    test = Redlines(test_string_1, test_string_2, markdown_style='none')
+    test = Redlines(test_string_1, test_string_2, markdown_style="none")
     assert test.output_markdown == expected_md
 
 
 def test_compare():
     test_string_1 = "The quick brown fox jumps over the lazy dog."
     test_string_2 = "The quick brown fox walks past the lazy dog."
-    expected_md = "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog."
-    test = Redlines(test_string_1, markdown_style='none')
+    expected_md = (
+        "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog."
+    )
+    test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
 
     # When compare is called twice on the same test string, the first result is given
     assert test.compare(test_string_2) == expected_md
 
-    assert test.compare(
-        "The quick brown fox jumps over the dog.") == "The quick brown fox jumps over the <del>lazy </del>dog."
+    assert (
+        test.compare("The quick brown fox jumps over the dog.")
+        == "The quick brown fox jumps over the <del>lazy </del>dog."
+    )
 
     # Not giving the Redline object anything to test with throws an error.
     test = Redlines(test_string_1)
@@ -61,43 +80,44 @@ def test_opcodes_error():
 
 def test_source():
     test_string_1 = "The quick brown fox jumps over the lazy dog."
-    test = Redlines(test_string_1, markdown_style='none')
+    test = Redlines(test_string_1, markdown_style="none")
     assert test.source == test_string_1
 
 
 def test_markdown_style():
     test_string_1 = "The quick brown fox jumps over the lazy dog."
     test_string_2 = "The quick brown fox walks past the lazy dog."
-    expected_md = "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog."
-    test = Redlines(test_string_1, markdown_style='none')
+    expected_md = (
+        "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog."
+    )
+    test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
 
-    expected_md = 'The quick brown fox <span style="color:red;font-weight:700;text-decoration:line-through;">jumps ' \
-                  'over </span><span style="color:red;font-weight:700;">walks past </span>the lazy dog.'
-    test = Redlines(test_string_1, markdown_style='red')
+    expected_md = (
+        'The quick brown fox <span style="color:red;font-weight:700;text-decoration:line-through;">jumps '
+        'over </span><span style="color:red;font-weight:700;">walks past </span>the lazy dog.'
+    )
+    test = Redlines(test_string_1, markdown_style="red")
     assert test.compare(test_string_2) == expected_md
 
 
 def test_newline_handling():
-    test_string_1 = '''
+    test_string_1 = """
 Happy Saturday,
 
 Thank you for reaching out, have a good weekend
 
 Sophia 
-'''
-    test_string_2 = '''Happy Saturday,
+"""
+    test_string_2 = """Happy Saturday,
 
 Thank you for reaching out. Have a good weekend.
 
-Sophia.'''
-    expected_md = 'Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekendSophia </del><ins>weekend.</ins>\n\n<ins>Sophia.</ins>'
-    test = Redlines(test_string_1, markdown_style='none')
+Sophia."""
+    expected_md = "Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekendSophia </del><ins>weekend.</ins>\n\n<ins>Sophia.</ins>"
+    test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
-
 
     expected_md = 'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekendSophia </span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;">Sophia.</span>'
-    test = Redlines(test_string_1, markdown_style='red')
+    test = Redlines(test_string_1, markdown_style="red")
     assert test.compare(test_string_2) == expected_md
-
-


### PR DESCRIPTION
Here is the code that shows the problem.
```python
from redlines import Redlines
import markdown
from IPython.display import display, Markdown,  HTML
test_string_1 = '''
Happy Saturday,

Thank you for reaching out, have a good weekend

Sophia 
'''
test_string_2 = '''Happy Saturday,

Thank you for reaching out. Have a good weekend.

Sophia.'''

diff = Redlines(test_string_1 ,test_string_2, markdown_style="red")
html=markdown.markdown(diff.output_markdown)
display(HTML(html))
```

When displaying Markdown in a Jupyter Notebook or on a webpage, we need to convert it to HTML. For most Markdown packages, they will convert two or more consecutive '\n' to a new `<p>`. The example above is very common when comparing an original email to a proofread and corrected text. The current code cannot handle it properly.

Because diff.output_markdown may include
```
<del>weekend\n\nSophia \n</del><ins>weekend.\n\n\n\nSophia.</ins>'
```
The markdown package will add a `</p><p>` to replace the `\n\n` and it turned into `<p>...<del>..</p> <p>...</del>...</p>`
The `<del></del>` is broken.

The result looks like this.

<p>Happy Saturday,</p><p>Thank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend</p><p>Sophia </del><ins>weekend.</p><p>Sophia.</ins></p>



### Solution:
1. For `delete` and `replace`, and for _seq1, remove all the `\n` in the string because we will keep `\n` in _seq2, and the markdown will add the right number of `<p>` in the HTML.
2. For `insert` and `replace`, and for _seq2, move the substring with two or more `\n` out of the tag `<del></del>` or `<ins> </ins>`.

The new result looks like this.

<p>Happy Saturday,</p>
<p>Thank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekendSophia </del><ins>weekend.</ins></p>
<p><ins>Sophia.</ins></p>
