### PR TITLE
Solving the problem when '\n' is in the text

### DIFF
--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -32,7 +32,7 @@ def split_paragraphs(text: str) -> list[str]:
     result = []
     for s in splitted_text:
         if s and not re.fullmatch(space_pattern, s):
-            result.append(s)
+            result.append(s.strip())
 
     return result
 

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -132,6 +132,8 @@ class Redlines:
             if tag == 'equal':
                 temp_str="".join(self._seq1[i1:i2])
                 temp_str=re.sub('¶ ','\n\n',temp_str)
+                # here is we use '¶ ' instead of ' ¶ ', because the leading space will be included in the previous token, 
+                # according to tokenizer = re.compile(r"((?:[^()\s]+|[().?!-])\s*)")
                 result.append(temp_str)
             elif tag == 'insert':
                 temp_str = ''.join(self._seq2[j1:j2])

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -28,14 +28,15 @@ def split_paragraphs(text: str) -> list[str]:
     :return: a list of paragraphs.
     """
 
-    splitted_text=re.split(paragraph_pattern, text)
+    splitted_text = re.split(paragraph_pattern, text)
     result = []
     for s in splitted_text:
         if s and not re.fullmatch(space_pattern, s):
             result.append(s)
-    
+
     return result
-    
+
+
 def split_paragraphs_and_tokenize_text(text: str) -> list[list[str]]:
     """
     Splits a string into a list of paragraphs. Then, each paragraph is tokenized.
@@ -48,11 +49,20 @@ def split_paragraphs_and_tokenize_text(text: str) -> list[list[str]]:
     paragraphs = split_paragraphs(text)
     return [tokenize_text(p) for p in paragraphs]
 
+
 class Redlines:
     _source: str = None
     _test: str = None
-    _seqlist1: list[list[str]] = [] # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the source.
-    _seqlist2: list[list[str]] = [] # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the test.
+    _seqlist1: list[
+        list[str]
+    ] = (
+        []
+    )  # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the source.
+    _seqlist2: list[
+        list[str]
+    ] = (
+        []
+    )  # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the test.
 
     @property
     def source(self):
@@ -93,7 +103,7 @@ class Redlines:
     @property
     def opcodes(self) -> list[list[tuple[str, int, int, int, int]]]:
         """
-        Return a list of list. 
+        Return a list of list.
         Each sub-list represent a paragraph, and is a list of 5-tuples describing how to turn a `source` paragraph into a `test` paragraph
         Each 5-tuple represents a single change in the source and test text.
         The 5-tuple has the following format:
@@ -107,21 +117,21 @@ class Redlines:
             raise ValueError(
                 "No test string was provided when the function was called, or during initialisation."
             )
-        
+
         # If the number of pararagraphs in the source is greater than the number of paragraphs in the test,
-        # we add empty lists to the end of the list of lists, and vice versa. 
-        
+        # we add empty lists to the end of the list of lists, and vice versa.
+
         len_seqlist1 = len(self._seqlist1)
         len_seqlist2 = len(self._seqlist2)
-        if len_seqlist1>len_seqlist2:
-            for i in range(len_seqlist1-len_seqlist2):
+        if len_seqlist1 > len_seqlist2:
+            for i in range(len_seqlist1 - len_seqlist2):
                 self._seqlist2.append([])
-        elif len_seqlist2>len_seqlist1:
-            for i in range(len_seqlist2-len_seqlist1):
+        elif len_seqlist2 > len_seqlist1:
+            for i in range(len_seqlist2 - len_seqlist1):
                 self._seqlist1.append([])
         assert len(self._seqlist1) == len(self._seqlist2)
 
-        result=[]
+        result = []
         for seq1, seq2 in zip(self._seqlist1, self._seqlist2):
             matcher = SequenceMatcher(None, seq1, seq2)
             result.append(matcher.get_opcodes())
@@ -149,16 +159,21 @@ class Redlines:
             }
         for opcode, seq1, seq2 in zip(self.opcodes, self._seqlist1, self._seqlist2):
             for tag, i1, i2, j1, j2 in opcode:
-                if tag == 'equal':
+                if tag == "equal":
                     result.append("".join(seq1[i1:i2]))
-                elif tag == 'insert':
-                    result.append(f"<{md_styles['ins'][0]}>{''.join(seq2[j1:j2])}</{md_styles['ins'][1]}>")
-                elif tag == 'delete':
-                    result.append(f"<{md_styles['del'][0]}>{''.join(seq1[i1:i2])}</{md_styles['del'][1]}>")
-                elif tag == 'replace':
+                elif tag == "insert":
+                    result.append(
+                        f"<{md_styles['ins'][0]}>{''.join(seq2[j1:j2])}</{md_styles['ins'][1]}>"
+                    )
+                elif tag == "delete":
                     result.append(
                         f"<{md_styles['del'][0]}>{''.join(seq1[i1:i2])}</{md_styles['del'][1]}>"
-                        f"<{md_styles['ins'][0]}>{''.join(seq2[j1:j2])}</{md_styles['ins'][1]}>")
+                    )
+                elif tag == "replace":
+                    result.append(
+                        f"<{md_styles['del'][0]}>{''.join(seq1[i1:i2])}</{md_styles['del'][1]}>"
+                        f"<{md_styles['ins'][0]}>{''.join(seq2[j1:j2])}</{md_styles['ins'][1]}>"
+                    )
 
             result.append("\n\n")
         # pop the last '\n\n'

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -1,31 +1,58 @@
 from __future__ import annotations
 
 import re
+from difflib import SequenceMatcher
 
 tokenizer = re.compile(r"((?:[^()\s]+|[().?!-])\s*)")
 
-# This pattern matches two or more newlines, and any spaces between them.
-newline_pattern = re.compile(r"((?:\n[ ]*){2,})")
+# This pattern matches one or more newline characters `\n`, and any spaces between them.
+# It is used to split the text into paragraphs.
+# (?:\n *) is a non-capturing group that must start with a \n or \r and be followed by zero or more spaces.
+# ((?:\n *)+) is the previous non-capturing group repeated one or more times.
+paragraph_pattern = re.compile(r"((?:\n *)+)")
+
+space_pattern = re.compile(r"(\s+)")
 
 
 def tokenize_text(text: str) -> list[str]:
     return re.findall(tokenizer, text)
 
 
-def split_newlines(text: str) -> tuple(list[str], list[str]):
+def split_paragraphs(text: str) -> list[str]:
     """
-    Splits a string into a list of strings, and a list of substring containing newlines.
-    :param text: The text to split.
-    :return: A tuple containing the list of strings, and a list of substring containing newlines.
-    """
-    return re.split(newline_pattern, text), re.findall(newline_pattern, text)
+    Splits a string into a list of paragraphs.
+    For example, if the text is "Hello\nWorld\nThis is a test", the result will be:
+    ['Hello', 'World', 'This is a test']
 
+    :param text: The text to split.
+    :return: a list of paragraphs.
+    """
+
+    splitted_text=re.split(paragraph_pattern, text)
+    result = []
+    for s in splitted_text:
+        if s and not re.fullmatch(space_pattern, s):
+            result.append(s)
+    
+    return result
+    
+def split_paragraphs_and_tokenize_text(text: str) -> list[list[str]]:
+    """
+    Splits a string into a list of paragraphs. Then, each paragraph is tokenized.
+    For example, if the text is "Hello World\nThis is a test. \n This is another test.", the result will be:
+    [['Hello ', 'World'], ['This ', 'is ', 'a ', 'test.'], ['This ', 'is ', 'another ', 'test.']]
+
+    :param text: The text to split.
+    :return: a list of lists of tokens.
+    """
+    paragraphs = split_paragraphs(text)
+    return [tokenize_text(p) for p in paragraphs]
 
 class Redlines:
     _source: str = None
     _test: str = None
-    _seq1: list[str] = None
-    _seq2: list[str] = None
+    _seqlist1: list[list[str]] = [] # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the source.
+    _seqlist2: list[list[str]] = [] # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the test.
 
     @property
     def source(self):
@@ -38,7 +65,7 @@ class Redlines:
     @source.setter
     def source(self, value):
         self._source = value
-        self._seq1 = tokenize_text(value)
+        self._seqlist1 = split_paragraphs_and_tokenize_text(value)
 
     @property
     def test(self):
@@ -48,7 +75,7 @@ class Redlines:
     @test.setter
     def test(self, value):
         self._test = value
-        self._seq2 = tokenize_text(value)
+        self._seqlist2 = split_paragraphs_and_tokenize_text(value)
 
     def __init__(self, source: str, test: str | None = None, **options):
         """
@@ -65,20 +92,43 @@ class Redlines:
             self.compare()
 
     @property
-    def opcodes(self) -> list[tuple[str, int, int, int, int]]:
+    def opcodes(self) -> list[list[tuple[str, int, int, int, int]]]:
         """
-        Return list of 5-tuples describing how to turn `source` into `test`.
-        Similar to `SequenceMatcher.get_opcodes`
+        Return a list of list. (list of 5-tuples describing how to turn a `source` paragraph into a `test` paragraph)
+        Each sub-list represent a paragraph, and is a list of 5-tuples describing how to turn a `source` paragraph into a `test` paragraph
+        Each 5-tuple represents a single change in the source and test text.
+        The 5-tuple has the following format:
+        (tag, i1, i2, j1, j2)
+        where:
+        - tag is a string describing the type of change, and could be 'equal', 'replace', 'insert', 'delete'
+        - i1, i2, j1, j2 are integers, where i1 and j1 are the starting and ending indices of the change
         """
-        if self._seq2 is None:
+
+
+        if not self._seqlist2:
             raise ValueError(
                 "No test string was provided when the function was called, or during initialisation."
             )
+        
+        # If the number of pararagraphs in the source is greater than the number of paragraphs in the test,
+        # we add empty lists to the end of the list of lists.
+        
+        len_seqlist1 = len(self._seqlist1)
+        len_seqlist2 = len(self._seqlist2)
+        if len_seqlist1>len_seqlist2:
+            for i in range(len_seqlist1-len_seqlist2):
+                self._seqlist2.append([])
+        elif len_seqlist2>len_seqlist1:
+            for i in range(len_seqlist2-len_seqlist1):
+                self._seqlist1.append([])
+        assert len(self._seqlist1) == len(self._seqlist2)
 
-        from difflib import SequenceMatcher
+        result=[]
+        for seq1, seq2 in zip(self._seqlist1, self._seqlist2):
+            matcher = SequenceMatcher(None, seq1, seq2)
+            result.append(matcher.get_opcodes())
 
-        matcher = SequenceMatcher(None, self._seq1, self._seq2)
-        return matcher.get_opcodes()
+        return result
 
     @property
     def output_markdown(self) -> str:
@@ -99,40 +149,22 @@ class Redlines:
                     "span",
                 ),
             }
+        for opcode, seq1, seq2 in zip(self.opcodes, self._seqlist1, self._seqlist2):
+            for tag, i1, i2, j1, j2 in opcode:
+                if tag == 'equal':
+                    result.append("".join(seq1[i1:i2]))
+                elif tag == 'insert':
+                    result.append(f"<{md_styles['ins'][0]}>{''.join(seq2[j1:j2])}</{md_styles['ins'][1]}>")
+                elif tag == 'delete':
+                    result.append(f"<{md_styles['del'][0]}>{''.join(seq1[i1:i2])}</{md_styles['del'][1]}>")
+                elif tag == 'replace':
+                    result.append(
+                        f"<{md_styles['del'][0]}>{''.join(seq1[i1:i2])}</{md_styles['del'][1]}>"
+                        f"<{md_styles['ins'][0]}>{''.join(seq2[j1:j2])}</{md_styles['ins'][1]}>")
 
-        for tag, i1, i2, j1, j2 in self.opcodes:
-            if tag == "equal":
-                result.append("".join(self._seq1[i1:i2]))
-            elif tag == "insert":
-                temp_str = "".join(self._seq2[j1:j2])
-                temp_list, temp_newline_list = split_newlines(temp_str)
-                for s in temp_list:
-                    if s and s in temp_newline_list:
-                        result.append(s)
-                    else:
-                        result.append(
-                            f"<{md_styles['ins'][0]}>{s}</{md_styles['ins'][1]}>"
-                        )
-            elif tag == "delete":
-                temp_str = "".join(self._seq1[i1:i2]).replace("\n", "")
-                result.append(
-                    f"<{md_styles['del'][0]}>{temp_str}</{md_styles['del'][1]}>"
-                )
-            elif tag == "replace":
-                temp_str = "".join(self._seq1[i1:i2]).replace("\n", "")
-                result.append(
-                    f"<{md_styles['del'][0]}>{temp_str}</{md_styles['del'][1]}>"
-                )
-
-                temp_str = "".join(self._seq2[j1:j2])
-                temp_list, temp_newline_list = split_newlines(temp_str)
-                for s in temp_list:
-                    if s and s in temp_newline_list:
-                        result.append(s)
-                    else:
-                        result.append(
-                            f"<{md_styles['ins'][0]}>{s}</{md_styles['ins'][1]}>"
-                        )
+            result.append("\n\n")
+        # pop the last '\n\n'
+        result.pop()
 
         return "".join(result)
 

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -6,7 +6,7 @@ tokenizer = re.compile(r"((?:[^()\s]+|[().?!-])\s*)")
 
 # This pattern matches one or more newline characters `\n`, and any spaces between them.
 # It is used to split the text into paragraphs.
-# (?:\n *) is a non-capturing group that must start with a \n or \r and be followed by zero or more spaces.
+# (?:\n *) is a non-capturing group that must start with a \n   and be followed by zero or more spaces.
 # ((?:\n *)+) is the previous non-capturing group repeated one or more times.
 paragraph_pattern = re.compile(r"((?:\n *)+)")
 

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -52,7 +52,6 @@ def concatenate_paragraphs_and_add_chr_182(text: str) -> str:
         result.append(p)
         result.append(' ¶ ')
          # Add a string ' ¶ ' between paragraphs.
-         # In case that '¶' is already in the text, we add two more spaces to make it a little bit special.
     if len(paragraphs) > 0:
         result.pop()
 
@@ -132,11 +131,11 @@ class Redlines:
         for tag, i1, i2, j1, j2 in self.opcodes:
             if tag == 'equal':
                 temp_str="".join(self._seq1[i1:i2])
-                temp_str=re.sub(' ¶ ','\n\n',temp_str)
+                temp_str=re.sub('¶ ','\n\n',temp_str)
                 result.append(temp_str)
             elif tag == 'insert':
                 temp_str = ''.join(self._seq2[j1:j2])
-                splits = re.split(' ¶ ', temp_str)
+                splits = re.split('¶ ', temp_str)
                 for split in splits:
                     result.append(f"<{md_styles['ins'][0]}>{split}</{md_styles['ins'][1]}>")
                     result.append('\n\n')
@@ -149,7 +148,7 @@ class Redlines:
                 result.append(
                     f"<{md_styles['del'][0]}>{''.join(self._seq1[i1:i2])}</{md_styles['del'][1]}>")
                 temp_str = ''.join(self._seq2[j1:j2])
-                splits = re.split(' ¶ ', temp_str)
+                splits = re.split('¶ ', temp_str)
                 for split in splits:
                     result.append(f"<{md_styles['ins'][0]}>{split}</{md_styles['ins'][1]}>")
                     result.append('\n\n')

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -89,12 +89,11 @@ class Redlines:
         self.options = options
         if test:
             self.test = test
-            self.compare()
 
     @property
     def opcodes(self) -> list[list[tuple[str, int, int, int, int]]]:
         """
-        Return a list of list. (list of 5-tuples describing how to turn a `source` paragraph into a `test` paragraph)
+        Return a list of list. 
         Each sub-list represent a paragraph, and is a list of 5-tuples describing how to turn a `source` paragraph into a `test` paragraph
         Each 5-tuple represents a single change in the source and test text.
         The 5-tuple has the following format:
@@ -104,14 +103,13 @@ class Redlines:
         - i1, i2, j1, j2 are integers, where i1 and j1 are the starting and ending indices of the change
         """
 
-
         if not self._seqlist2:
             raise ValueError(
                 "No test string was provided when the function was called, or during initialisation."
             )
         
         # If the number of pararagraphs in the source is greater than the number of paragraphs in the test,
-        # we add empty lists to the end of the list of lists.
+        # we add empty lists to the end of the list of lists, and vice versa. 
         
         len_seqlist1 = len(self._seqlist1)
         len_seqlist2 = len(self._seqlist2)

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -8,15 +8,16 @@ tokenizer = re.compile(r"((?:[^()\s]+|[().?!-])\s*)")
 newline_pattern = re.compile(r"((?:\n[ ]*){2,})")
 
 
-
 def tokenize_text(text: str) -> list[str]:
     return re.findall(tokenizer, text)
+
 
 def split_newlines(text: str) -> tuple(list[str], list[str]):
     """
     Splits a string into a list of strings, and a list of substring containing newlines.
     :param text: The text to split.
-    :return: A tuple containing the list of strings, and a list of substring containing newlines."""
+    :return: A tuple containing the list of strings, and a list of substring containing newlines.
+    """
     return re.split(newline_pattern, text), re.findall(newline_pattern, text)
 
 
@@ -70,9 +71,12 @@ class Redlines:
         Similar to `SequenceMatcher.get_opcodes`
         """
         if self._seq2 is None:
-            raise ValueError('No test string was provided when the function was called, or during initialisation.')
+            raise ValueError(
+                "No test string was provided when the function was called, or during initialisation."
+            )
 
         from difflib import SequenceMatcher
+
         matcher = SequenceMatcher(None, self._seq1, self._seq2)
         return matcher.get_opcodes()
 
@@ -80,16 +84,21 @@ class Redlines:
     def output_markdown(self) -> str:
         """Returns the delta in markdown format."""
         result = []
-        style = 'red'
+        style = "red"
 
-        if self.options.get('markdown_style'):
-            style = self.options['markdown_style']
+        if self.options.get("markdown_style"):
+            style = self.options["markdown_style"]
 
-        if style == 'none':
-            md_styles = {"ins": ('ins', 'ins'), "del": ('del', 'del')}
-        elif 'red':
-            md_styles = {"ins": ('span style="color:red;font-weight:700;"', 'span'),
-                         "del": ('span style="color:red;font-weight:700;text-decoration:line-through;"', 'span')}
+        if style == "none":
+            md_styles = {"ins": ("ins", "ins"), "del": ("del", "del")}
+        elif "red":
+            md_styles = {
+                "ins": ('span style="color:red;font-weight:700;"', "span"),
+                "del": (
+                    'span style="color:red;font-weight:700;text-decoration:line-through;"',
+                    "span",
+                ),
+            }
 
         for tag, i1, i2, j1, j2 in self.opcodes:
             if tag == "equal":
@@ -105,14 +114,14 @@ class Redlines:
                             f"<{md_styles['ins'][0]}>{s}</{md_styles['ins'][1]}>"
                         )
             elif tag == "delete":
-                temp_str = "".join(self._seq1[i1:i2]).replace('\n', '')
+                temp_str = "".join(self._seq1[i1:i2]).replace("\n", "")
                 result.append(
                     f"<{md_styles['del'][0]}>{temp_str}</{md_styles['del'][1]}>"
                 )
             elif tag == "replace":
-                temp_str1 = "".join(self._seq1[i1:i2]).replace('\n', '')
+                temp_str = "".join(self._seq1[i1:i2]).replace("\n", "")
                 result.append(
-                    f"<{md_styles['del'][0]}>{temp_str1}</{md_styles['del'][1]}>"
+                    f"<{md_styles['del'][0]}>{temp_str}</{md_styles['del'][1]}>"
                 )
 
                 temp_str = "".join(self._seq2[j1:j2])
@@ -128,7 +137,6 @@ class Redlines:
         return "".join(result)
 
     def compare(self, test: str | None = None, output: str = "markdown", **options):
-
         """
         Compare `test` with `source`, and produce a delta in a format specified by `output`.
 
@@ -142,10 +150,12 @@ class Redlines:
             else:
                 self.test = test
         elif self.test is None:
-            raise ValueError('No test string was provided when the function was called, or during initialisation.')
+            raise ValueError(
+                "No test string was provided when the function was called, or during initialisation."
+            )
 
         if options:
             self.options = options
 
-        if output == 'markdown':
+        if output == "markdown":
             return self.output_markdown

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -132,7 +132,7 @@ class Redlines:
             if tag == 'equal':
                 temp_str="".join(self._seq1[i1:i2])
                 temp_str=re.sub('¶ ','\n\n',temp_str)
-                # here is we use '¶ ' instead of ' ¶ ', because the leading space will be included in the previous token, 
+                # here we use '¶ ' instead of ' ¶ ', because the leading space will be included in the previous token, 
                 # according to tokenizer = re.compile(r"((?:[^()\s]+|[().?!-])\s*)")
                 result.append(temp_str)
             elif tag == 'insert':

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -20,7 +20,7 @@ def tokenize_text(text: str) -> list[str]:
 
 def split_paragraphs(text: str) -> list[str]:
     """
-    Splits a string into a list of paragraphs.
+    Splits a string into a list of paragraphs. One or more `\n` splits the paragraphs.
     For example, if the text is "Hello\nWorld\nThis is a test", the result will be:
     ['Hello', 'World', 'This is a test']
 
@@ -40,7 +40,7 @@ def split_paragraphs(text: str) -> list[str]:
 def split_paragraphs_and_tokenize_text(text: str) -> list[list[str]]:
     """
     Splits a string into a list of paragraphs. Then, each paragraph is tokenized.
-    For example, if the text is "Hello World\nThis is a test. \n This is another test.", the result will be:
+    For example, if the text is "Hello World\nThis is a test.\n This is another test.", the result will be:
     [['Hello ', 'World'], ['This ', 'is ', 'a ', 'test.'], ['This ', 'is ', 'another ', 'test.']]
 
     :param text: The text to split.
@@ -53,16 +53,8 @@ def split_paragraphs_and_tokenize_text(text: str) -> list[list[str]]:
 class Redlines:
     _source: str = None
     _test: str = None
-    _seqlist1: list[
-        list[str]
-    ] = (
-        []
-    )  # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the source.
-    _seqlist2: list[
-        list[str]
-    ] = (
-        []
-    )  # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the test.
+    _seqlist1: list[list[str]] = [] # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the source.
+    _seqlist2: list[list[str]] = [] # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the test.
 
     @property
     def source(self):
@@ -129,7 +121,6 @@ class Redlines:
         elif len_seqlist2 > len_seqlist1:
             for i in range(len_seqlist2 - len_seqlist1):
                 self._seqlist1.append([])
-        assert len(self._seqlist1) == len(self._seqlist2)
 
         result = []
         for seq1, seq2 in zip(self._seqlist1, self._seqlist2):
@@ -176,7 +167,7 @@ class Redlines:
                     )
 
             result.append("\n\n")
-        # pop the last '\n\n'
+        # pop the last '\n\n', which is after the last paragraph.
         result.pop()
 
         return "".join(result)

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from difflib import SequenceMatcher
 
 tokenizer = re.compile(r"((?:[^()\s]+|[().?!-])\s*)")
 
@@ -37,24 +36,33 @@ def split_paragraphs(text: str) -> list[str]:
     return result
 
 
-def split_paragraphs_and_tokenize_text(text: str) -> list[list[str]]:
+def concatenate_paragraphs_and_add_chr_182(text: str) -> str:
     """
-    Splits a string into a list of paragraphs. Then, each paragraph is tokenized.
-    For example, if the text is "Hello World\nThis is a test.\n This is another test.", the result will be:
-    [['Hello ', 'World'], ['This ', 'is ', 'a ', 'test.'], ['This ', 'is ', 'another ', 'test.']]
+    Split paragraphs and concatenate them. Then add a character '¶' between paragraphs.
+    For example, if the text is "Hello\nWorld\nThis is a test", the result will be:
+    "Hello¶World¶This is a test"
 
     :param text: The text to split.
-    :return: a list of lists of tokens.
+    :return: a list of paragraphs.
     """
     paragraphs = split_paragraphs(text)
-    return [tokenize_text(p) for p in paragraphs]
 
+    result= []
+    for p in paragraphs:
+        result.append(p)
+        result.append(' ¶ ')
+         # Add a string ' ¶ ' between paragraphs.
+         # In case that '¶' is already in the text, we add two more spaces to make it a little bit special.
+    if len(paragraphs) > 0:
+        result.pop()
+
+    return ''.join(result)
 
 class Redlines:
     _source: str = None
     _test: str = None
-    _seqlist1: list[list[str]] = [] # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the source.
-    _seqlist2: list[list[str]] = [] # This is a list of list. Each sub-list is a sequence of tokens in a paragraph in the test.
+    _seq1: list[str] = None
+    _seq2: list[str] = None
 
     @property
     def source(self):
@@ -67,7 +75,7 @@ class Redlines:
     @source.setter
     def source(self, value):
         self._source = value
-        self._seqlist1 = split_paragraphs_and_tokenize_text(value)
+        self._seq1 = tokenize_text(concatenate_paragraphs_and_add_chr_182(value))
 
     @property
     def test(self):
@@ -77,7 +85,7 @@ class Redlines:
     @test.setter
     def test(self, value):
         self._test = value
-        self._seqlist2 = split_paragraphs_and_tokenize_text(value)
+        self._seq2 = tokenize_text(concatenate_paragraphs_and_add_chr_182(value))
 
     def __init__(self, source: str, test: str | None = None, **options):
         """
@@ -91,88 +99,67 @@ class Redlines:
         self.options = options
         if test:
             self.test = test
+            # self.compare()
 
     @property
-    def opcodes(self) -> list[list[tuple[str, int, int, int, int]]]:
+    def opcodes(self) -> list[tuple[str, int, int, int, int]]:
         """
-        Return a list of list.
-        Each sub-list represent a paragraph, and is a list of 5-tuples describing how to turn a `source` paragraph into a `test` paragraph
-        Each 5-tuple represents a single change in the source and test text.
-        The 5-tuple has the following format:
-        (tag, i1, i2, j1, j2)
-        where:
-        - tag is a string describing the type of change, and could be 'equal', 'replace', 'insert', 'delete'
-        - i1, i2, j1, j2 are integers, where i1 and j1 are the starting and ending indices of the change
+        Return list of 5-tuples describing how to turn `source` into `test`.
+        Similar to `SequenceMatcher.get_opcodes`
         """
+        if self._seq2 is None:
+            raise ValueError('No test string was provided when the function was called, or during initialisation.')
 
-        if not self._seqlist2:
-            raise ValueError(
-                "No test string was provided when the function was called, or during initialisation."
-            )
-
-        # If the number of pararagraphs in the source is greater than the number of paragraphs in the test,
-        # we add empty lists to the end of the list of lists, and vice versa.
-
-        len_seqlist1 = len(self._seqlist1)
-        len_seqlist2 = len(self._seqlist2)
-        if len_seqlist1 > len_seqlist2:
-            for i in range(len_seqlist1 - len_seqlist2):
-                self._seqlist2.append([])
-        elif len_seqlist2 > len_seqlist1:
-            for i in range(len_seqlist2 - len_seqlist1):
-                self._seqlist1.append([])
-
-        result = []
-        for seq1, seq2 in zip(self._seqlist1, self._seqlist2):
-            matcher = SequenceMatcher(None, seq1, seq2)
-            result.append(matcher.get_opcodes())
-
-        return result
+        from difflib import SequenceMatcher
+        matcher = SequenceMatcher(None, self._seq1, self._seq2)
+        return matcher.get_opcodes()
 
     @property
     def output_markdown(self) -> str:
         """Returns the delta in markdown format."""
         result = []
-        style = "red"
+        style = 'red'
 
-        if self.options.get("markdown_style"):
-            style = self.options["markdown_style"]
+        if self.options.get('markdown_style'):
+            style = self.options['markdown_style']
 
-        if style == "none":
-            md_styles = {"ins": ("ins", "ins"), "del": ("del", "del")}
-        elif "red":
-            md_styles = {
-                "ins": ('span style="color:red;font-weight:700;"', "span"),
-                "del": (
-                    'span style="color:red;font-weight:700;text-decoration:line-through;"',
-                    "span",
-                ),
-            }
-        for opcode, seq1, seq2 in zip(self.opcodes, self._seqlist1, self._seqlist2):
-            for tag, i1, i2, j1, j2 in opcode:
-                if tag == "equal":
-                    result.append("".join(seq1[i1:i2]))
-                elif tag == "insert":
-                    result.append(
-                        f"<{md_styles['ins'][0]}>{''.join(seq2[j1:j2])}</{md_styles['ins'][1]}>"
-                    )
-                elif tag == "delete":
-                    result.append(
-                        f"<{md_styles['del'][0]}>{''.join(seq1[i1:i2])}</{md_styles['del'][1]}>"
-                    )
-                elif tag == "replace":
-                    result.append(
-                        f"<{md_styles['del'][0]}>{''.join(seq1[i1:i2])}</{md_styles['del'][1]}>"
-                        f"<{md_styles['ins'][0]}>{''.join(seq2[j1:j2])}</{md_styles['ins'][1]}>"
-                    )
+        if style == 'none':
+            md_styles = {"ins": ('ins', 'ins'), "del": ('del', 'del')}
+        elif 'red':
+            md_styles = {"ins": ('span style="color:red;font-weight:700;"', 'span'),
+                         "del": ('span style="color:red;font-weight:700;text-decoration:line-through;"', 'span')}
 
-            result.append("\n\n")
-        # pop the last '\n\n', which is after the last paragraph.
-        result.pop()
+        for tag, i1, i2, j1, j2 in self.opcodes:
+            if tag == 'equal':
+                temp_str="".join(self._seq1[i1:i2])
+                temp_str=re.sub(' ¶ ','\n\n',temp_str)
+                result.append(temp_str)
+            elif tag == 'insert':
+                temp_str = ''.join(self._seq2[j1:j2])
+                splits = re.split(' ¶ ', temp_str)
+                for split in splits:
+                    result.append(f"<{md_styles['ins'][0]}>{split}</{md_styles['ins'][1]}>")
+                    result.append('\n\n')
+                if len(splits)>0:
+                    result.pop()
+            elif tag == 'delete':
+                result.append(f"<{md_styles['del'][0]}>{''.join(self._seq1[i1:i2])}</{md_styles['del'][1]}>")
+                # for 'delete', we make no change, because otherwise there will be two times '\n\n' than the original text.
+            elif tag == 'replace':
+                result.append(
+                    f"<{md_styles['del'][0]}>{''.join(self._seq1[i1:i2])}</{md_styles['del'][1]}>")
+                temp_str = ''.join(self._seq2[j1:j2])
+                splits = re.split(' ¶ ', temp_str)
+                for split in splits:
+                    result.append(f"<{md_styles['ins'][0]}>{split}</{md_styles['ins'][1]}>")
+                    result.append('\n\n')
+                if len(splits)>0:
+                    result.pop()
 
         return "".join(result)
 
     def compare(self, test: str | None = None, output: str = "markdown", **options):
+
         """
         Compare `test` with `source`, and produce a delta in a format specified by `output`.
 
@@ -186,12 +173,10 @@ class Redlines:
             else:
                 self.test = test
         elif self.test is None:
-            raise ValueError(
-                "No test string was provided when the function was called, or during initialisation."
-            )
+            raise ValueError('No test string was provided when the function was called, or during initialisation.')
 
         if options:
             self.options = options
 
-        if output == "markdown":
+        if output == 'markdown':
             return self.output_markdown

--- a/tests/test_redline.py
+++ b/tests/test_redline.py
@@ -115,11 +115,13 @@ Sophia
 Thank you for reaching out. Have a good weekend.
 
 Sophia."""
-    expected_md = "Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend</del><ins>weekend.</ins>\n\n<del>Sophia </del><ins>Sophia.</ins>"
+    expected_md = \
+    'Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend</del><ins>weekend.</ins>\n\n<del>Sophia</del><ins>Sophia.</ins>'
     test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
 
-    expected_md = 'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia </span><span style="color:red;font-weight:700;">Sophia.</span>'
+    expected_md = \
+    'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia</span><span style="color:red;font-weight:700;">Sophia.</span>'
     test = Redlines(test_string_1, markdown_style="red")
     assert test.compare(test_string_2) == expected_md
 
@@ -173,7 +175,7 @@ Thank you for reaching out. Have a good weekend.
 
 Sophia."""
 
-    expected_md = 'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Best,</span><span style="color:red;font-weight:700;">Sophia.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia </span>'
-
+    expected_md = \
+    'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Best,</span><span style="color:red;font-weight:700;">Sophia.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia</span>'
     test = Redlines(test_string_1, test_string_2, markdown_style="red")
     assert test.output_markdown == expected_md

--- a/tests/test_redline.py
+++ b/tests/test_redline.py
@@ -1,7 +1,6 @@
 import pytest
 
 from redlines import Redlines
-from redlines.redlines import split_paragraphs_and_tokenize_text
 
 
 @pytest.mark.parametrize(
@@ -116,47 +115,10 @@ Thank you for reaching out. Have a good weekend.
 
 Sophia."""
     expected_md = \
-    'Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend</del><ins>weekend.</ins>\n\n<del>Sophia</del><ins>Sophia.</ins>'
+    'Happy Saturday, \n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend </del><ins>weekend. </ins>\n\n<del>Sophia</del><ins>Sophia.</ins>'
     test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
 
-    expected_md = \
-    'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia</span><span style="color:red;font-weight:700;">Sophia.</span>'
-    test = Redlines(test_string_1, markdown_style="red")
-    assert test.compare(test_string_2) == expected_md
-
-
-@pytest.mark.parametrize(
-    "test_string, expected_list",
-    [
-        (
-            "Hello World\nThis is a test.\n This is another test.",
-            [
-                ["Hello ", "World"],
-                ["This ", "is ", "a ", "test."],
-                ["This ", "is ", "another ", "test."],
-            ],
-        ),
-        (
-            "Hello World\n\r\nThis is a test.\n\n This is another test.",
-            [
-                ["Hello ", "World"],
-                ["This ", "is ", "a ", "test."],
-                ["This ", "is ", "another ", "test."],
-            ],
-        ),
-        (
-            "\n Hello World\n\r\nThis is a test.\n    \r\t\n This is another test.\n",
-            [
-                ["Hello ", "World"],
-                ["This ", "is ", "a ", "test."],
-                ["This ", "is ", "another ", "test."],
-            ],
-        ),
-    ],
-)
-def test_split_paragraphs_and_tokenize_text(test_string, expected_list):
-    assert split_paragraphs_and_tokenize_text(test_string) == expected_list
 
 
 def test_different_number_of_paragraphs():
@@ -176,6 +138,6 @@ Thank you for reaching out. Have a good weekend.
 Sophia."""
 
     expected_md = \
-    'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Best,</span><span style="color:red;font-weight:700;">Sophia.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia</span>'
-    test = Redlines(test_string_1, test_string_2, markdown_style="red")
+    'Happy Saturday, \n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend </del><ins>weekend. </ins>\n\n<del>Best, ¶ Sophia</del><ins>Sophia.</ins>'
+    test = Redlines(test_string_1, test_string_2, markdown_style="none")
     assert test.output_markdown == expected_md

--- a/tests/test_redline.py
+++ b/tests/test_redline.py
@@ -102,7 +102,7 @@ def test_markdown_style():
     assert test.compare(test_string_2) == expected_md
 
 
-def test_newline_handling():
+def test_paragraphs_handling():
     test_string_1 = """
 Happy Saturday,
 
@@ -145,3 +145,24 @@ Sophia."""
 )
 def test_split_paragraphs_and_tokenize_text(test_string,expected_list):
     assert split_paragraphs_and_tokenize_text(test_string) == expected_list
+
+def test_different_number_of_paragraphs():
+    test_string_1 = """
+Happy Saturday,
+
+Thank you for reaching out, have a good weekend
+
+Best,
+
+Sophia 
+"""
+    test_string_2 = """Happy Saturday,
+
+Thank you for reaching out. Have a good weekend.
+
+Sophia."""
+
+    expected_md='Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Best,</span><span style="color:red;font-weight:700;">Sophia.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia </span>'
+
+    test = Redlines(test_string_1, test_string_2, markdown_style="red")
+    assert test.output_markdown == expected_md

--- a/tests/test_redline.py
+++ b/tests/test_redline.py
@@ -115,7 +115,7 @@ Sophia
 Thank you for reaching out. Have a good weekend.
 
 Sophia."""
-    expected_md = 'Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend</del><ins>weekend.</ins>\n\n<del>Sophia </del><ins>Sophia.</ins>'
+    expected_md = "Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend</del><ins>weekend.</ins>\n\n<del>Sophia </del><ins>Sophia.</ins>"
     test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
 
@@ -123,28 +123,39 @@ Sophia."""
     test = Redlines(test_string_1, markdown_style="red")
     assert test.compare(test_string_2) == expected_md
 
+
 @pytest.mark.parametrize(
     "test_string, expected_list",
     [
         (
             "Hello World\nThis is a test.\n This is another test.",
-            [['Hello ', 'World'], ['This ', 'is ', 'a ', 'test.'], ['This ', 'is ', 'another ', 'test.']],
+            [
+                ["Hello ", "World"],
+                ["This ", "is ", "a ", "test."],
+                ["This ", "is ", "another ", "test."],
+            ],
         ),
-
         (
             "Hello World\n\r\nThis is a test.\n\n This is another test.",
-            [['Hello ', 'World'], ['This ', 'is ', 'a ', 'test.'], ['This ', 'is ', 'another ', 'test.']],
+            [
+                ["Hello ", "World"],
+                ["This ", "is ", "a ", "test."],
+                ["This ", "is ", "another ", "test."],
+            ],
         ),
-
-                (
+        (
             "\n Hello World\n\r\nThis is a test.\n    \r\t\n This is another test.\n",
-            [['Hello ', 'World'], ['This ', 'is ', 'a ', 'test.'], ['This ', 'is ', 'another ', 'test.']],
+            [
+                ["Hello ", "World"],
+                ["This ", "is ", "a ", "test."],
+                ["This ", "is ", "another ", "test."],
+            ],
         ),
-
     ],
 )
-def test_split_paragraphs_and_tokenize_text(test_string,expected_list):
+def test_split_paragraphs_and_tokenize_text(test_string, expected_list):
     assert split_paragraphs_and_tokenize_text(test_string) == expected_list
+
 
 def test_different_number_of_paragraphs():
     test_string_1 = """
@@ -162,7 +173,7 @@ Thank you for reaching out. Have a good weekend.
 
 Sophia."""
 
-    expected_md='Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Best,</span><span style="color:red;font-weight:700;">Sophia.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia </span>'
+    expected_md = 'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Best,</span><span style="color:red;font-weight:700;">Sophia.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia </span>'
 
     test = Redlines(test_string_1, test_string_2, markdown_style="red")
     assert test.output_markdown == expected_md

--- a/tests/test_redline.py
+++ b/tests/test_redline.py
@@ -76,3 +76,28 @@ def test_markdown_style():
                   'over </span><span style="color:red;font-weight:700;">walks past </span>the lazy dog.'
     test = Redlines(test_string_1, markdown_style='red')
     assert test.compare(test_string_2) == expected_md
+
+
+def test_newline_handling():
+    test_string_1 = '''
+Happy Saturday,
+
+Thank you for reaching out, have a good weekend
+
+Sophia 
+'''
+    test_string_2 = '''Happy Saturday,
+
+Thank you for reaching out. Have a good weekend.
+
+Sophia.'''
+    expected_md = 'Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekendSophia </del><ins>weekend.</ins>\n\n<ins>Sophia.</ins>'
+    test = Redlines(test_string_1, markdown_style='none')
+    assert test.compare(test_string_2) == expected_md
+
+
+    expected_md = 'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekendSophia </span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;">Sophia.</span>'
+    test = Redlines(test_string_1, markdown_style='red')
+    assert test.compare(test_string_2) == expected_md
+
+

--- a/tests/test_redline.py
+++ b/tests/test_redline.py
@@ -3,48 +3,67 @@ import pytest
 from redlines import Redlines
 
 
-@pytest.mark.parametrize("test_string_1, test_string_2, expected_md", [
-    ("The quick brown fox jumps over the dog.",
-     "The quick brown fox jumps over the lazy dog.",
-     "The quick brown fox jumps over the <ins>lazy </ins>dog.")
-])
+@pytest.mark.parametrize(
+    "test_string_1, test_string_2, expected_md",
+    [
+        (
+            "The quick brown fox jumps over the dog.",
+            "The quick brown fox jumps over the lazy dog.",
+            "The quick brown fox jumps over the <ins>lazy </ins>dog.",
+        )
+    ],
+)
 def test_redline_add(test_string_1, test_string_2, expected_md):
-    test = Redlines(test_string_1, test_string_2, markdown_style='none')
+    test = Redlines(test_string_1, test_string_2, markdown_style="none")
     assert test.output_markdown == expected_md
 
 
-@pytest.mark.parametrize("test_string_1, test_string_2, expected_md", [
-    ("The quick brown fox jumps over the lazy dog.",
-     "The quick brown fox jumps over the dog.",
-     "The quick brown fox jumps over the <del>lazy </del>dog.")
-])
+@pytest.mark.parametrize(
+    "test_string_1, test_string_2, expected_md",
+    [
+        (
+            "The quick brown fox jumps over the lazy dog.",
+            "The quick brown fox jumps over the dog.",
+            "The quick brown fox jumps over the <del>lazy </del>dog.",
+        )
+    ],
+)
 def test_redline_delete(test_string_1, test_string_2, expected_md):
-    test = Redlines(test_string_1, test_string_2, markdown_style='none')
+    test = Redlines(test_string_1, test_string_2, markdown_style="none")
     assert test.output_markdown == expected_md
 
 
-@pytest.mark.parametrize("test_string_1, test_string_2, expected_md", [
-    ("The quick brown fox jumps over the lazy dog.",
-     "The quick brown fox walks past the lazy dog.",
-     "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog.")
-])
+@pytest.mark.parametrize(
+    "test_string_1, test_string_2, expected_md",
+    [
+        (
+            "The quick brown fox jumps over the lazy dog.",
+            "The quick brown fox walks past the lazy dog.",
+            "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog.",
+        )
+    ],
+)
 def test_redline_replace(test_string_1, test_string_2, expected_md):
-    test = Redlines(test_string_1, test_string_2, markdown_style='none')
+    test = Redlines(test_string_1, test_string_2, markdown_style="none")
     assert test.output_markdown == expected_md
 
 
 def test_compare():
     test_string_1 = "The quick brown fox jumps over the lazy dog."
     test_string_2 = "The quick brown fox walks past the lazy dog."
-    expected_md = "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog."
-    test = Redlines(test_string_1, markdown_style='none')
+    expected_md = (
+        "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog."
+    )
+    test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
 
     # When compare is called twice on the same test string, the first result is given
     assert test.compare(test_string_2) == expected_md
 
-    assert test.compare(
-        "The quick brown fox jumps over the dog.") == "The quick brown fox jumps over the <del>lazy </del>dog."
+    assert (
+        test.compare("The quick brown fox jumps over the dog.")
+        == "The quick brown fox jumps over the <del>lazy </del>dog."
+    )
 
     # Not giving the Redline object anything to test with throws an error.
     test = Redlines(test_string_1)
@@ -61,43 +80,44 @@ def test_opcodes_error():
 
 def test_source():
     test_string_1 = "The quick brown fox jumps over the lazy dog."
-    test = Redlines(test_string_1, markdown_style='none')
+    test = Redlines(test_string_1, markdown_style="none")
     assert test.source == test_string_1
 
 
 def test_markdown_style():
     test_string_1 = "The quick brown fox jumps over the lazy dog."
     test_string_2 = "The quick brown fox walks past the lazy dog."
-    expected_md = "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog."
-    test = Redlines(test_string_1, markdown_style='none')
+    expected_md = (
+        "The quick brown fox <del>jumps over </del><ins>walks past </ins>the lazy dog."
+    )
+    test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
 
-    expected_md = 'The quick brown fox <span style="color:red;font-weight:700;text-decoration:line-through;">jumps ' \
-                  'over </span><span style="color:red;font-weight:700;">walks past </span>the lazy dog.'
-    test = Redlines(test_string_1, markdown_style='red')
+    expected_md = (
+        'The quick brown fox <span style="color:red;font-weight:700;text-decoration:line-through;">jumps '
+        'over </span><span style="color:red;font-weight:700;">walks past </span>the lazy dog.'
+    )
+    test = Redlines(test_string_1, markdown_style="red")
     assert test.compare(test_string_2) == expected_md
 
 
 def test_newline_handling():
-    test_string_1 = '''
+    test_string_1 = """
 Happy Saturday,
 
 Thank you for reaching out, have a good weekend
 
 Sophia 
-'''
-    test_string_2 = '''Happy Saturday,
+"""
+    test_string_2 = """Happy Saturday,
 
 Thank you for reaching out. Have a good weekend.
 
-Sophia.'''
-    expected_md = 'Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekendSophia </del><ins>weekend.</ins>\n\n<ins>Sophia.</ins>'
-    test = Redlines(test_string_1, markdown_style='none')
+Sophia."""
+    expected_md = "Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekendSophia </del><ins>weekend.</ins>\n\n<ins>Sophia.</ins>"
+    test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
-
 
     expected_md = 'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekendSophia </span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;">Sophia.</span>'
-    test = Redlines(test_string_1, markdown_style='red')
+    test = Redlines(test_string_1, markdown_style="red")
     assert test.compare(test_string_2) == expected_md
-
-

--- a/tests/test_redline.py
+++ b/tests/test_redline.py
@@ -1,6 +1,7 @@
 import pytest
 
 from redlines import Redlines
+from redlines.redlines import split_paragraphs_and_tokenize_text
 
 
 @pytest.mark.parametrize(
@@ -114,10 +115,33 @@ Sophia
 Thank you for reaching out. Have a good weekend.
 
 Sophia."""
-    expected_md = "Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekendSophia </del><ins>weekend.</ins>\n\n<ins>Sophia.</ins>"
+    expected_md = 'Happy Saturday,\n\nThank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend</del><ins>weekend.</ins>\n\n<del>Sophia </del><ins>Sophia.</ins>'
     test = Redlines(test_string_1, markdown_style="none")
     assert test.compare(test_string_2) == expected_md
 
-    expected_md = 'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekendSophia </span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;">Sophia.</span>'
+    expected_md = 'Happy Saturday,\n\nThank you for reaching <span style="color:red;font-weight:700;text-decoration:line-through;">out, have </span><span style="color:red;font-weight:700;">out. Have </span>a good <span style="color:red;font-weight:700;text-decoration:line-through;">weekend</span><span style="color:red;font-weight:700;">weekend.</span>\n\n<span style="color:red;font-weight:700;text-decoration:line-through;">Sophia </span><span style="color:red;font-weight:700;">Sophia.</span>'
     test = Redlines(test_string_1, markdown_style="red")
     assert test.compare(test_string_2) == expected_md
+
+@pytest.mark.parametrize(
+    "test_string, expected_list",
+    [
+        (
+            "Hello World\nThis is a test.\n This is another test.",
+            [['Hello ', 'World'], ['This ', 'is ', 'a ', 'test.'], ['This ', 'is ', 'another ', 'test.']],
+        ),
+
+        (
+            "Hello World\n\r\nThis is a test.\n\n This is another test.",
+            [['Hello ', 'World'], ['This ', 'is ', 'a ', 'test.'], ['This ', 'is ', 'another ', 'test.']],
+        ),
+
+                (
+            "\n Hello World\n\r\nThis is a test.\n    \r\t\n This is another test.\n",
+            [['Hello ', 'World'], ['This ', 'is ', 'a ', 'test.'], ['This ', 'is ', 'another ', 'test.']],
+        ),
+
+    ],
+)
+def test_split_paragraphs_and_tokenize_text(test_string,expected_list):
+    assert split_paragraphs_and_tokenize_text(test_string) == expected_list


### PR DESCRIPTION
Here is the code that shows the problem.
```python
from redlines import Redlines
import markdown
from IPython.display import display, Markdown,  HTML
test_string_1 = '''
Happy Saturday,

Thank you for reaching out, have a good weekend

Sophia 
'''
test_string_2 = '''Happy Saturday,

Thank you for reaching out. Have a good weekend.

Sophia.'''

diff = Redlines(test_string_1 ,test_string_2, markdown_style="none")
html=markdown.markdown(diff.output_markdown)
display(HTML(html))
```

When displaying Markdown in a Jupyter Notebook or on a webpage, we need to convert it to HTML. For most Markdown packages, they will convert two or more consecutive '\n' to a new `<p>`. The example above is a very common use case when comparing an original email to a proofread and corrected email. The current code cannot handle it properly.

Because diff.output_markdown include code like
```
<del>weekend\n\nSophia \n</del><ins>weekend.\n\n\n\nSophia.</ins>'
```
The markdown package will add a `</p><p>` to replace the `\n\n` between `<del></del>` and `<ins></ins>`
The `<del></del>` or `<ins></ins>` will be broken.

The `html=markdown.markdown(diff.output_markdown)` result looks like this.

<p>Happy Saturday,</p><p>Thank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend</p><p>Sophia </del><ins>weekend.</p><p>Sophia.</ins></p>

You see two Sophia because `<del>weekend\n\nSophia \n</del>` is broken by a `<p>`.

### Solution:
Break the text into paragraphs. For each paragraph, which is now guaranteed to not include '\n', we generate the output_markdown and concatenate them. Add `\n\n` between paragraphs.

The new html result looks like this.

<p>Happy Saturday,</p><p>Thank you for reaching <del>out, have </del><ins>out. Have </ins>a good <del>weekend</del><ins>weekend.</ins></p><p><del>Sophia </del><ins>Sophia.</ins></p>
