### PR TITLE
[Feat] Add Document Base Class

### DIFF
--- a/redlines/__init__.py
+++ b/redlines/__init__.py
@@ -1,1 +1,2 @@
 from .redlines import Redlines
+from .document import *

--- a/redlines/document.py
+++ b/redlines/document.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+
+
+class Document(ABC):
+    """An abstract base class used as a common data interchange with the redlines with formats other than plain text"""
+
+    @property
+    @abstractmethod
+    def text(self) -> str:
+        """
+        This property is used by the redlines library to obtain the text to compare. Implement this method to return
+        the text to be compared by redlines.
+        """
+        pass
+
+
+class PlainTextFile(Document):
+    """For plain text files"""
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def __init__(self, file_path):
+        with open(file_path) as f:
+            self._text = f.read()

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -4,6 +4,8 @@ import re
 
 from rich.text import Text
 
+from redlines.document import Document
+
 # This regular expression matches a group of characters that can include any character except for parentheses
 # and whitespace characters (which include spaces, tabs, and line breaks) or any character
 # that is a parenthesis or punctuation mark (.?!-).
@@ -101,7 +103,9 @@ class Redlines:
         self._test = value
         self._seq2 = tokenize_text(concatenate_paragraphs_and_add_chr_182(value))
 
-    def __init__(self, source: str, test: str | None = None, **options):
+    def __init__(
+        self, source: str | Document, test: str | Document | None = None, **options
+    ):
         """
         Redline is a class used to compare text, and producing human-readable differences or deltas
         which look like track changes in Microsoft Word.
@@ -109,10 +113,10 @@ class Redlines:
         :param source: The source text to be used as a basis for comparison.
         :param test: Optional test text to compare with the source.
         """
-        self.source = source
+        self.source = source.text if isinstance(source, Document) else source
         self.options = options
         if test:
-            self.test = test
+            self.test = test.text if isinstance(test, Document) else test
             # self.compare()
 
     @property

--- a/tests/documents/PlainTextFile/source.txt
+++ b/tests/documents/PlainTextFile/source.txt
@@ -1,0 +1,1 @@
+The quick brown fox jumps over the lazy dog.

--- a/tests/documents/PlainTextFile/test.txt
+++ b/tests/documents/PlainTextFile/test.txt
@@ -1,0 +1,1 @@
+The quick brown fox walks past the lazy dog.

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,0 +1,17 @@
+from redlines import Redlines
+
+
+def test_PlainTextFile_text():
+    from redlines.document import PlainTextFile
+
+    source = PlainTextFile("documents/PlainTextFile/source.txt")
+    assert source.text == "The quick brown fox jumps over the lazy dog."
+
+    test = PlainTextFile("documents/PlainTextFile/test.txt")
+    assert test.text == "The quick brown fox walks past the lazy dog."
+
+    redline = Redlines(source, test)
+    assert (
+        redline.output_markdown
+        == "The quick brown fox <span style='color:red;font-weight:700;text-decoration:line-through;'>jumps over </span><span style='color:green;font-weight:700;'>walks past </span>the lazy dog."
+    )

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -2,12 +2,12 @@ from redlines import Redlines
 
 
 def test_PlainTextFile_text():
-    from redlines.document import PlainTextFile
+    from redlines import PlainTextFile
 
-    source = PlainTextFile("documents/PlainTextFile/source.txt")
+    source = PlainTextFile("tests/documents/PlainTextFile/source.txt")
     assert source.text == "The quick brown fox jumps over the lazy dog."
 
-    test = PlainTextFile("documents/PlainTextFile/test.txt")
+    test = PlainTextFile("tests/documents/PlainTextFile/test.txt")
     assert test.text == "The quick brown fox walks past the lazy dog."
 
     redline = Redlines(source, test)


### PR DESCRIPTION
A simple method is introduced to support a larger variety of file formats. 
Anyone who would like to add support for a new format will create a new implementation Document, which provides a read-only property called `text`. The redlines library now supports Document implementations as an argument/input, and will look to the Document.text property to get the text to compare.

A new PlainTextFile Document implementation is introduced to show how this would work.

Fixes #16 
Fixes #24 