### PR TITLE
Normalize tokens by stripping whitespace for comparison

### DIFF
--- a/redlines/processor.py
+++ b/redlines/processor.py
@@ -138,6 +138,9 @@ class WholeDocumentProcessor(RedlinesProcessor):
 
         seq_source = tokenize_text(concatenate_paragraphs_and_add_chr_182(self.source))
         seq_test = tokenize_text(concatenate_paragraphs_and_add_chr_182(self.test))
+        # Normalize tokens by stripping whitespace for comparison
+        # This allows the matcher to focus on content differences rather than whitespace variations
+        # while still preserving the original tokens (including whitespace) for display in the output
         seq_source_normalized = [token.strip() for token in seq_source]
         seq_test_normalized = [token.strip() for token in seq_test]
 

--- a/redlines/processor.py
+++ b/redlines/processor.py
@@ -138,10 +138,12 @@ class WholeDocumentProcessor(RedlinesProcessor):
 
         seq_source = tokenize_text(concatenate_paragraphs_and_add_chr_182(self.source))
         seq_test = tokenize_text(concatenate_paragraphs_and_add_chr_182(self.test))
+        seq_source_normalized = [token.strip() for token in seq_source]
+        seq_test_normalized = [token.strip() for token in seq_test]
 
         from difflib import SequenceMatcher
 
-        matcher = SequenceMatcher(None, seq_source, seq_test)
+        matcher = SequenceMatcher(None, seq_source_normalized, seq_test_normalized)
 
         return [
             Redline(


### PR DESCRIPTION
## Current behaviour
The original text is 
```
Draft dated 19 November 2024
```
The modified text is
```
Draft dated 19 November 2024
John Doe comments 19 November 2024
```
The resulting opcodes
```
[('equal', 0, 4, 0, 4), ('insert', 4, 4, 4, 11), ('equal', 4, 5, 11, 12)]
```

This translates to the following redline
```
Draft dated 19 November <ins>2024 </ins>
<ins>John Doe comments 19 November </ins>2024
```
This seems quite non-intuitive. The addition is at the end, not in the middle.

## Proposed solution
The problem arises because the tokenization process tokenizes the two strings as below:
```
['Draft ', 'dated ', '19 ', 'November ', '2024']
['Draft ', 'dated ', '19 ', 'November ', '2024 ', '¶ ', 'John ', 'Doe ', 'comments ', '19 ', 'November ', '2024']
```

As `2024<space>` does not match `2024` we are left with the strange matching behaviour.

This PR ensures we use normalized tokens (without spaces) for opcode generation but then use the original tokens for further processing.

The result is a more intuitive redline, even though I'm not sure about the value of the `<ins></ins>` here.:
```
Draft dated 19 November 2024<ins></ins>
<ins>John Doe comments 19 November 2024</ins>
```

