### PR TITLE
Fix: Implementing Character-Level Diffing in Limited Situations

### DIFF
--- a/redlines/processor.py
+++ b/redlines/processor.py
@@ -191,9 +191,15 @@ class WholeDocumentProcessor(RedlinesProcessor):
                     )
 
                     if refined_opcodes:
-                        # Replace the original redline with the refined one(s)
-                        refined_redlines.extend(refined_opcodes)
-                        continue
+                        # Skip refinements that only insert or delete trailing punctuation,
+                        # so that tokens like "weekend"->"weekend." are handled as full-token replacements
+                        if not (
+                            len(refined_opcodes) == 2
+                            and refined_opcodes[0].opcodes[0] == "equal"
+                            and refined_opcodes[1].opcodes[0] in ("insert", "delete")
+                        ):
+                            refined_redlines.extend(refined_opcodes)
+                            continue
 
             # If we didn't refine this redline, keep the original
             refined_redlines.append(redline)
@@ -230,6 +236,60 @@ class WholeDocumentProcessor(RedlinesProcessor):
             if source_token[-i] != test_token[-i]:
                 break
             suffix_len = i
+
+        # Special case for trailing punctuation differences
+        # Handle case where one token ends with punctuation and the other doesn't
+        if source_token.rstrip(".!?,;:") == test_token.rstrip(".!?,;:") and (
+            source_token[-1] in ".!?,;:" or test_token[-1] in ".!?,;:"
+        ):
+            # Create special handling for this case
+            base_token = source_token.rstrip(".!?,;:")
+            result = []
+            # Add the common part
+            if base_token:
+                result.append(
+                    Redline(
+                        source_chunk=source_chunk,
+                        test_chunk=test_chunk,
+                        opcodes=(
+                            "equal",
+                            i1,
+                            i1 + len(base_token),
+                            j1,
+                            j1 + len(base_token),
+                        ),
+                    )
+                )
+            # Handle the punctuation differences
+            if source_token != base_token:
+                result.append(
+                    Redline(
+                        source_chunk=source_chunk,
+                        test_chunk=test_chunk,
+                        opcodes=(
+                            "delete",
+                            i1 + len(base_token),
+                            i1 + len(source_token),
+                            j1 + len(base_token),
+                            j1 + len(base_token),
+                        ),
+                    )
+                )
+            if test_token != base_token:
+                result.append(
+                    Redline(
+                        source_chunk=source_chunk,
+                        test_chunk=test_chunk,
+                        opcodes=(
+                            "insert",
+                            i1 + len(base_token),
+                            i1 + len(base_token),
+                            j1 + len(base_token),
+                            j1 + len(test_token),
+                        ),
+                    )
+                )
+            return result
 
         # If either prefix or suffix is different (but not both), use character-level diffing
         is_prefix_change = prefix_len == 0 and suffix_len > 0

--- a/redlines/redlines.py
+++ b/redlines/redlines.py
@@ -41,7 +41,11 @@ class Redlines:
         self._seq2 = tokenize_text(concatenate_paragraphs_and_add_chr_182(value))
 
     def __init__(
-        self, source: str | Document, test: str | Document | None = None, **options
+        self,
+        source: str | Document,
+        test: str | Document | None = None,
+        character_level_diffing: bool = True,
+        **options,
     ):
         """
         Redline is a class used to compare text, and producing human-readable differences or deltas
@@ -85,7 +89,10 @@ class Redlines:
         if test:
             self.test = test.text if isinstance(test, Document) else test
             # self.compare()
-        self.processor = WholeDocumentProcessor()
+        self.character_level_diffing = character_level_diffing
+        self.processor = WholeDocumentProcessor(
+            character_level_diffing=character_level_diffing
+        )
 
     @property
     def opcodes(self) -> list[tuple[str, int, int, int, int]]:


### PR DESCRIPTION
Closes #44 

We make a limited two pass diffing approach which replace words that share similarities  by running a second character level diff on just those pairs (like "dinner"/"dinners"). This is only activated when the change is only on one word/token has changes in the beginning or end of the token. This is a balance on performance and improvements on common cases. You might find inconsistencies or puzzling cases why character level is or is not activated. Feedback is always welcome. 